### PR TITLE
Feat/#5 arena startTime 기록 API 분리

### DIFF
--- a/src/main/java/com/example/KeyboardArenaProject/dto/arena/ArenaDetailResponse.java
+++ b/src/main/java/com/example/KeyboardArenaProject/dto/arena/ArenaDetailResponse.java
@@ -23,6 +23,7 @@ public class ArenaDetailResponse {
     String writer;
     int boardRank;
     LocalDateTime createdDate;
+    boolean ifFirstTry;
     int participates;
     int comments;
     int likes;
@@ -30,11 +31,12 @@ public class ArenaDetailResponse {
     List<CommentResponse> commentResponses;
 
     @Builder
-    ArenaDetailResponse(User user, Board board, List<Comment> comment, int participates, String writer){
+    ArenaDetailResponse(User user, Board board, List<Comment> comment, int participates,boolean ifFirstTry, String writer){
         this.userTopBarInfo = new UserTopBarInfo(user);
         this.boardId = board.getBoardId();
         this.title = board.getTitle();
         this.content = board.getContent();
+        this.ifFirstTry = ifFirstTry;
         this.writer =writer;
         this.boardRank = board.getBoardRank();
         this.createdDate = board.getCreatedDate();

--- a/src/main/java/com/example/KeyboardArenaProject/dto/arena/ArenaStartTimeResponse.java
+++ b/src/main/java/com/example/KeyboardArenaProject/dto/arena/ArenaStartTimeResponse.java
@@ -12,5 +12,4 @@ import java.time.LocalDateTime;
 @Getter
 public class ArenaStartTimeResponse {
     LocalDateTime startTime;
-
 }

--- a/src/main/java/com/example/KeyboardArenaProject/dto/arena/ArenaStartTimeResponse.java
+++ b/src/main/java/com/example/KeyboardArenaProject/dto/arena/ArenaStartTimeResponse.java
@@ -1,0 +1,16 @@
+package com.example.KeyboardArenaProject.dto.arena;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class ArenaStartTimeResponse {
+    LocalDateTime startTime;
+
+}

--- a/src/main/java/com/example/KeyboardArenaProject/repository/ClearedRepository.java
+++ b/src/main/java/com/example/KeyboardArenaProject/repository/ClearedRepository.java
@@ -13,8 +13,8 @@ import java.util.List;
 public interface ClearedRepository extends JpaRepository<Cleared, UserBoardCompositeKey> {
     List<Cleared> findAllByCompositeId_BoardId(String boardId);
 
-    @Query("SELECT CASE WHEN COUNT(e) > 0 THEN true ELSE false END FROM Cleared e WHERE e.compositeId = :id")
-    boolean ifClearedById(UserBoardCompositeKey id);
+    @Query("SELECT CASE WHEN e.clearTime is NULL then false ELSE true END FROM Cleared  e where e.compositeId =:id")
+    Boolean ifClearedById(UserBoardCompositeKey id);
 
     Long countByCompositeId_BoardId(String boardId);
 

--- a/src/main/resources/static/js/Arena.js
+++ b/src/main/resources/static/js/Arena.js
@@ -18,6 +18,64 @@ if (createButton) {
     })
 }
 
+
+
+document.addEventListener('DOMContentLoaded', function() {
+    const startButton = document.getElementById('start-button');
+    const retryButton = document.getElementById('retry-button');
+    const userTypedContent = document.getElementById('user-typed-content');
+    const startTimeElement = document.getElementById('start-time');
+    function sendAsyncRequest() {
+        //콘텐츠 입력창 보이게 함
+        userTypedContent.style.display = 'block';
+
+        fetch(`/arenas/${boardId}/start`)
+            .then(response => response.json()) // 서버로부터 받은 JSON 응답을 파싱
+            .then(data => {
+                // 'start-time' 요소에 시작 시간을 표시
+                startTimeElement.innerText = `Start time: ${data.startTime}`;
+                startTimeElement.style.display = 'block';
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                startTimeElement.innerText = '시작 시간을 불러오는데 실패했습니다.\n 새로고침하세요.';
+                startTimeElement.style.display = 'block';
+            });
+    }
+
+    if (startButton) {
+        startButton.addEventListener('click', sendAsyncRequest);
+    }
+
+    if (retryButton) {
+        retryButton.addEventListener('click', sendAsyncRequest);
+    }
+});
+
+
+document.addEventListener('DOMContentLoaded', function() {
+    const form = document.getElementById('user-typed-content'); // 폼의 ID를 사용합니다.
+    const contentInput = document.getElementById('contentInput'); // 사용자가 입력한 텍스트를 가져올 요소의 ID입니다.
+
+    form.addEventListener('submit', function(event) {
+        event.preventDefault(); // 폼의 기본 제출 동작을 방지합니다.
+
+        const formData = new FormData();
+        formData.append('userTypedText', contentInput.value); // key-value 쌍을 FormData 객체에 추가합니다.
+
+        fetch(`/arenas/${boardId}`, {
+            method: 'POST',
+            body: formData
+        })
+            .then(response => response.text()) // 서버로부터 받은 응답을 텍스트로 변환
+            .then(data => {
+                alert(data); // 서버로부터 받은 텍스트 표사
+                window.location.href = `/arenas/${boardId}`; // 지정된 페이지로 리다이렉tus
+            })
+            .catch(error => console.error('Error:', error));
+    });
+});
+
 document.addEventListener('copy', function(e) {
     e.preventDefault(); // 복사 이벤트를 막음
 });

--- a/src/main/resources/templates/arenaDetail.html
+++ b/src/main/resources/templates/arenaDetail.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>Arena 상세보기</title>
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css">
-ㄹ    <noscript>
+    <noscript>
         <meta http-equiv="refresh" content="/arenas" />
     </noscript>
 
@@ -34,10 +34,16 @@
     <h5 th:text="'작성자: ' + ${arena.writer}"></h5>
     <h6 th:text="'작성일: ' + ${arena.createdDate}"></h6>
     <h6 th:text="'게시판 랭킹: ' + ${arena.boardRank}"></h6>
+
     <p th:text="${arena.content}"></p>
 
+    <button th:if="${arena.ifFirstTry} ==true" type="button" id="start-button" class="btn btn-primary btn-sm">시작</button>
+    <button th:if="${arena.ifFirstTry} == false" type="button" id="retry-button" class="btn btn-primary btn-sm">재시도</button>
+    <p id="start-time" style="display: none;"></p>
     <!-- 콘텐트 입력창 -->
-    <form th:action="@{/arenas/{boardId}(boardId=${arena.boardId})}" method="post">
+
+
+    <form id="user-typed-content" style="display:none;">
         <div class="form-group">
             <label for="contentInput">내용 입력</label>
             <textarea class="form-control" id="contentInput" name="userTypedText" rows="3"></textarea>
@@ -65,7 +71,11 @@
     </div>
 </div>
 
+<script th:inline="javascript">
+    var boardId = [[${arena.boardId}]];
+</script>
 <script src="/js/Arena.js"></script>
+
 <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"></script>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -15,7 +15,7 @@
 </header>
 <main>
     <button th:onclick="|location.href='@{/newFreeboard}'|">게시판 글 쓰기</button>
-    <button>투기장</button>
+    <button onclick="location.href='/arenas'">투기장</button>
     <button onclick="location.href='/board'">자유게시판</button>
     <button onclick="location.href='/mypage'">마이페이지</button>
 

--- a/src/main/resources/templates/newArena.html
+++ b/src/main/resources/templates/newArena.html
@@ -33,7 +33,7 @@
                 <section class="mb-5">
                     <textarea class="form-control h-25" rows="10" placeholder="내용" id="content"></textarea>
                 </section>
-                <!-- id가 있을 때는 '수정' 버튼, 없을 경우에는 '등록' 버튼 노출 -->
+
                 <button type="button" id="create-arena-btn" class="btn btn-primary btn-sm">등록</button>
             </article>
         </div>


### PR DESCRIPTION
# 구현한 것 
- startTime 기록 API 분리,
- userDetails.html에서 시작할 때 유저 입력창이 보이지 않도록 변경
![image](https://github.com/Garodden/keyboard-arena/assets/44630705/f4a0a85f-e061-4053-be92-5693555797bf)

    - 시작/재시도 버튼을 눌러야 유저 입력창이 보이며 startTime이 DB에 기록된다.
![image](https://github.com/Garodden/keyboard-arena/assets/44630705/f3e1ec1b-bae4-4670-8137-fa85589e9f08)

- POST로 유저 입력 텍스트를 보낼 시 결과에 따른 출력을 알림창으로 보여준다
![image](https://github.com/Garodden/keyboard-arena/assets/44630705/101acb99-179e-4aa1-b929-c19c62643ac4)
    - 알림창에서 확인을 누르면 User.details 사이트로 리다이렉팅 된다.

   