### PR TITLE
Feat: 댓글 단 게시물 전체 조회 api 구현

### DIFF
--- a/src/main/java/com/example/KeyboardArenaProject/controller/user/MyPageController.java
+++ b/src/main/java/com/example/KeyboardArenaProject/controller/user/MyPageController.java
@@ -3,6 +3,7 @@ package com.example.KeyboardArenaProject.controller.user;
 import java.util.List;
 
 import com.example.KeyboardArenaProject.dto.mypage.MyArenaResponse;
+import com.example.KeyboardArenaProject.dto.mypage.MyCommentedBoardsResponse;
 import com.example.KeyboardArenaProject.dto.user.ChangePwRequest;
 import com.example.KeyboardArenaProject.dto.user.MyPageInformation;
 import com.example.KeyboardArenaProject.entity.Board;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.server.ResponseStatusException;
 
 @Slf4j
 @Controller
@@ -109,6 +111,20 @@ public class MyPageController {
         }
     }
 
+    @GetMapping("/mypage/boards/commented")
+    public String getMyCommentedBoards(Model model) {
+        User user = userService.getCurrentUserInfo();
+        String id = user.getId();
+        try {
+            List<MyCommentedBoardsResponse> myCommentedBoards = myPageService.getMyCommentedBoards(id);
+            model.addAttribute("myCommentedBoards", myCommentedBoards);
+        } catch(MyPageService.MyCommentNotFoundException e) {
+            model.addAttribute("errorMessage", e.getMessage());
+        } catch (MyPageService.AuthorNotFoundException e) {
+            model.addAttribute("errorMessage", e.getMessage());
+        }
+        return "commentBoards";
+    }
     @GetMapping("/mypage/arenas")
     public String getMyArenas(Model model) {
         User user = userService.getCurrentUserInfo();
@@ -116,5 +132,5 @@ public class MyPageController {
         List<MyArenaResponse> myArenaDetails = myPageService.getMyArenaDetails(id);
         model.addAttribute("myArenas", myArenaDetails);
         return "myArenas";
-    }
+	}
 }

--- a/src/main/java/com/example/KeyboardArenaProject/dto/mypage/MyCommentedBoardsResponse.java
+++ b/src/main/java/com/example/KeyboardArenaProject/dto/mypage/MyCommentedBoardsResponse.java
@@ -1,0 +1,35 @@
+package com.example.KeyboardArenaProject.dto.mypage;
+
+import java.time.LocalDateTime;
+import com.example.KeyboardArenaProject.entity.Board;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MyCommentedBoardsResponse {
+	String boardId;
+	int boardType;
+	String title;
+	String author;
+	LocalDateTime createdDate;
+	int likes;
+	// List<CommentResponse> commentResponses;
+
+	@Builder
+	MyCommentedBoardsResponse(Board board, String author) {
+		this.boardId = board.getBoardId();
+		this.boardType = board.getBoardType();
+		this.title = board.getTitle();
+		this.author = author;
+		this.createdDate = board.getCreatedDate();
+		this.likes = board.getLikes();
+		// this.commentResponses = getCommentResponses();
+	}
+}

--- a/src/main/java/com/example/KeyboardArenaProject/repository/CommentRepository.java
+++ b/src/main/java/com/example/KeyboardArenaProject/repository/CommentRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, String> {
     List<Comment> findAllByBoardIdOrderByCreatedDateDesc(String BoardId);
+
+    List<Comment> findAllByIdOrderByCreatedDateDesc(String id);
 }

--- a/src/main/java/com/example/KeyboardArenaProject/repository/UserRepository.java
+++ b/src/main/java/com/example/KeyboardArenaProject/repository/UserRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.example.KeyboardArenaProject.entity.User;
 
 public interface UserRepository extends JpaRepository<User, String> {
+	Optional<User> findOptionalUserById(String id);
 	Optional<User> findByUserId(String userId);
 	Optional<User> findByEmail(String email);
 	boolean existsByUserId(String userId);

--- a/src/main/java/com/example/KeyboardArenaProject/service/user/UserService.java
+++ b/src/main/java/com/example/KeyboardArenaProject/service/user/UserService.java
@@ -116,6 +116,9 @@ public class UserService {
 	}
 
 
+	public Optional<User> findOptionalUserById(String id) {
+		return userRepository.findOptionalUserById(id);
+	}
 	public User findById(String id){
 		return userRepository.findById(id).orElse(null);
 	}
@@ -133,7 +136,7 @@ public class UserService {
 				.findPw("상동초").build();
 	}
 
-	public class UserNotFoundException extends RuntimeException {
+	public static class UserNotFoundException extends RuntimeException {
 		public UserNotFoundException(String message) {
 			super(message);
 		}

--- a/src/main/resources/templates/commentBoards.html
+++ b/src/main/resources/templates/commentBoards.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Keyboard Arena</title>
+    <link rel="stylesheet" type="text/css" href="/css/MyPageBoards.css" th:href="@{/css/MyPageBoards.css}">
+    <script defer src="/js/MyPageGetBoardDetails.js"></script>
+</head>
+<body>
+<h1>Keyboard Arena</h1>
+<h2>My Page</h2>
+<h3>내가 댓글 단 게시물</h3>
+<div th:unless="${myCommentedBoards}">
+    <p th:text="${errorMessage}"></p>
+</div>
+<table th:if="${myCommentedBoards}">
+    <thead>
+    <tr>
+        <th>번호</th>
+        <th>제목</th>
+        <th>작성자</th>
+        <th>작성일</th>
+        <th>좋아요</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr th:each="board, index : ${myCommentedBoards}" class="clickable-row" th:attr="board-id=${board.boardId}, board-type=${board.boardType}">
+        <td th:text="${index.index + 1}"></td>
+        <td th:text="${board.getTitle()}"></td>
+        <td th:text="${board.getAuthor()}"></td>
+        <td th:text="${#temporals.format(board.getCreatedDate(), 'yyyy.MM.dd')}"></td>
+        <td th:text="${board.getLikes()}"></td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/src/main/resources/templates/mypage.html
+++ b/src/main/resources/templates/mypage.html
@@ -19,7 +19,7 @@
     </form>
 <div>
     <a href="/mypage/arenas">내가 참전한 아레나</a><br>
-    <a href="#">내가 댓글 단 게시물</a><br>
+    <a href="/mypage/boards/commented">내가 댓글 단 게시물</a><br>
     <a href="/mypage/boards">내가 쓴 게시물</a><br>
     <a href="/mypage/boards/liked">좋아요 누른 게시물</a><br>
 </div>


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- #4 

## 📝 구현 사항
<!-- 과제에 대한 설명을 적어주세요 -->
- 댓글 단 게시물 전체를 조회합니다
- ✔ 화면: `mypage.html` 마이페이지 첫 화면 -> 'commentBoards.html' 내가 작성한 게시물 전체 조회 화면
- ✔ 마이페이지 작성한 게시물 전체 조회 api url: `GET ~/mypage/boards/commented`

## 캡쳐
🔽 마이페이지 접속 시 보이는 첫 화면
<img src="https://github.com/Garodden/keyboard-arena/assets/82032418/d283bd7c-1453-48dd-961c-ef862434adce" width="25%">

🔽 '내가 댓글 단 게시물' 링크 클릭 후 (개별 게시글 조회 가능)
<img src="https://github.com/Garodden/keyboard-arena/assets/82032418/0ce388af-d12b-4df5-9167-f58371be6efd" width="80%">

🔽 '내가 댓글 단 게시물' 링크 클릭 후, 작성한 댓글이 없는 경우
<img src="https://github.com/Garodden/keyboard-arena/assets/82032418/a37921f8-8047-458d-b320-a628ad9ddca3" width="25%">


## TODO
- [x] 댓글정보도..띄워주기? 😭 하다가 잘 안풀려서 일단 멈춤
- [x] admin 계정 -> whitelabel
- [x] UI 수정